### PR TITLE
Fix: Use floats for boolean logic in GLSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,20 +4,26 @@ project(MilkdropConverter VERSION 1.0.0 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-set(ENABLE_SYSTEM_PROJECTM_EVAL OFF CACHE BOOL "Use vendored projectm-eval")
-set(ENABLE_CXX_INTERFACE ON CACHE BOOL "Enable C++ interface for libprojectM")
-add_subdirectory(vendor/projectm-master)
+# projectm-eval requires bison and flex
+find_package(BISON)
+find_package(FLEX)
+
+# Add the projectm-eval subdirectory directly, bypassing the main projectM build
+add_subdirectory(vendor/projectm-master/vendor/projectm-eval)
 
 add_executable(MilkdropConverter
   MilkdropConverter.cpp
+  # Manually add the preset parser files to the build
+  vendor/projectm-master/src/libprojectM/PresetFileParser.cpp
 )
 
+# Add the include directory for PresetFileParser.hpp
 target_include_directories(MilkdropConverter PRIVATE
-  ${CMAKE_BINARY_DIR}/vendor/projectm-master/src/api/include
   vendor/projectm-master/src/libprojectM
-  vendor/projectm-master/src/api/include
 )
 
+# Link against the static projectm-eval library.
+# This will also automatically handle include directories.
 target_link_libraries(MilkdropConverter PRIVATE
-  libprojectM::projectM
+  projectM_eval
 )

--- a/test.frag.generated
+++ b/test.frag.generated
@@ -1,0 +1,122 @@
+#version 330 core
+
+out vec4 FragColor;
+in vec2 uv;
+
+float float_from_bool(bool b) { return b ? 1.0 : 0.0; }
+
+// Standard RaymarchVibe uniforms
+uniform float iTime;
+uniform vec2 iResolution;
+uniform float iFps;
+uniform float iFrame;
+uniform float iProgress;
+uniform vec4 iAudioBands;
+uniform vec4 iAudioBandsAtt;
+
+// Preset-specific uniforms with UI annotations
+uniform float u_b; // {"widget":"slider","default":0.0,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_g; // {"widget":"slider","default":0.0,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_r; // {"widget":"slider","default":0.0,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_decay; // {"widget":"slider","default":0.98,"min":0.9,"max":1.0,"step":0.001}
+uniform float u_a; // {"widget":"slider","default":1.0,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_wave_mystery; // {"widget":"slider","default":0.0,"min":-1.0,"max":1.0,"step":0.01}
+uniform float u_wave_a; // {"widget":"slider","default":1.0,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_rot; // {"widget":"slider","default":0.0,"min":-0.1,"max":0.1,"step":0.001}
+uniform float u_dy; // {"widget":"slider","default":0.0,"min":-0.1,"max":0.1,"step":0.001}
+uniform float u_zoomexp; // {"widget":"slider","default":1.0,"min":0.5,"max":2.0,"step":0.01}
+uniform float u_warp; // {"widget":"slider","default":1.0,"min":0.0,"max":2.0,"step":0.01}
+uniform float u_wave_x; // {"widget":"slider","default":0.5,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_sy; // {"widget":"slider","default":1.0,"min":0.5,"max":1.5,"step":0.01}
+uniform float u_cx; // {"widget":"slider","default":0.5,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_dx; // {"widget":"slider","default":0.0,"min":-0.1,"max":0.1,"step":0.001}
+uniform float u_cy; // {"widget":"slider","default":0.5,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_sx; // {"widget":"slider","default":1.0,"min":0.5,"max":1.5,"step":0.01}
+uniform float u_wave_y; // {"widget":"slider","default":0.5,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_zoom; // {"widget":"slider","default":1.0,"min":0.5,"max":1.5,"step":0.01}
+uniform float u_wave_r; // {"widget":"slider","default":0.5,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_wave_g; // {"widget":"slider","default":0.5,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_wave_b; // {"widget":"slider","default":0.5,"min":0.0,"max":1.0,"step":0.01}
+
+void main() {
+    // Initialize local variables from uniforms
+    float b = u_b;
+    float g = u_g;
+    float r = u_r;
+    float decay = u_decay;
+    float a = u_a;
+    float wave_mystery = u_wave_mystery;
+    float wave_a = u_wave_a;
+    float rot = u_rot;
+    float dy = u_dy;
+    float zoomexp = u_zoomexp;
+    float warp = u_warp;
+    float wave_x = u_wave_x;
+    float sy = u_sy;
+    float cx = u_cx;
+    float dx = u_dx;
+    float cy = u_cy;
+    float sx = u_sx;
+    float wave_y = u_wave_y;
+    float zoom = u_zoom;
+    float wave_r = u_wave_r;
+    float wave_g = u_wave_g;
+    float wave_b = u_wave_b;
+
+    // State variables
+    float q1 = 0.0;
+    float q2 = 0.0;
+    float q3 = 0.0;
+    float q4 = 0.0;
+    float q5 = 0.0;
+    float q6 = 0.0;
+    float q7 = 0.0;
+    float q8 = 0.0;
+    float q9 = 0.0;
+    float q10 = 0.0;
+    float q11 = 0.0;
+    float q12 = 0.0;
+    float q13 = 0.0;
+    float q14 = 0.0;
+    float q15 = 0.0;
+    float q16 = 0.0;
+    float q17 = 0.0;
+    float q18 = 0.0;
+    float q19 = 0.0;
+    float q20 = 0.0;
+    float q21 = 0.0;
+    float q22 = 0.0;
+    float q23 = 0.0;
+    float q24 = 0.0;
+    float q25 = 0.0;
+    float q26 = 0.0;
+    float q27 = 0.0;
+    float q28 = 0.0;
+    float q29 = 0.0;
+    float q30 = 0.0;
+    float q31 = 0.0;
+    float q32 = 0.0;
+    float t1 = 0.0;
+    float t2 = 0.0;
+    float t3 = 0.0;
+    float t4 = 0.0;
+    float t5 = 0.0;
+    float t6 = 0.0;
+    float t7 = 0.0;
+    float t8 = 0.0;
+    float my_user_var = 0.0;
+
+    // Per-frame logic
+    wave_r = (0.5 + (0.5 * sin(iTime)));
+    wave_g = (((iAudioBands.x > 1.2)) ? (1.0) : (0.5));
+    wave_b = ((iAudioBands.y)*(iAudioBands.y));
+    my_user_var = 1.0;
+
+    // Per-pixel logic
+    rot = (((my_user_var == 1.0)) ? (0.1) : (0.0));
+    r = (my_user_var * uv.x);
+    g = (wave_g * uv.y);
+    b = (((length(uv - vec2(0.5)) < 0.1)) ? (1.0) : (0.0));
+
+    FragColor = vec4(r, g, b, a);
+}


### PR DESCRIPTION
This commit refactors the GLSL code generation to correctly handle boolean logic as floating-point numbers, which is required to match MilkDrop's behavior. The previous implementation generated GLSL `bool` types for comparisons, leading to type mismatch errors when used in expressions expecting floats.

The main changes are:
- A `float_from_bool(bool)` helper function is now added to the GLSL preamble.
- All comparison operators (`>`, `==`, etc.) and boolean functions (`bnot`, `band`, `bor`) are now wrapped in `float_from_bool()` to ensure their result is a float (1.0 or 0.0).
- The `if` function code generation was made smarter to "unwrap" conditions that use `float_from_bool`, avoiding redundant checks and producing cleaner GLSL.
- The modulo operator is now correctly translated to the `mod()` function for float compatibility.

Additionally, significant changes were made to the build system to resolve dependency issues:
- The `CMakeLists.txt` was modified to build the `projectm-eval` library directly, bypassing the main `libprojectM` and its unnecessary OpenGL dependency.
- `PresetFileParser.cpp` and its header are now compiled directly.
- Stub functions for mutexes required by `projectm-eval` were added to resolve linker errors.