### PR TITLE
fix: Resolve black screen issue by applying warp and adding echo unif…

### DIFF
--- a/3dragonz.frag
+++ b/3dragonz.frag
@@ -69,6 +69,7 @@ uniform sampler2D iChannel2;
 uniform sampler2D iChannel3;
 
 // Preset-specific uniforms with UI annotations
+uniform float u_echo_alpha = 0.0; // {"widget":"slider","default":0.0,"min":0.0,"max":1.0,"step":0.01}
 uniform float u_mv_b = 0.499900; // {"widget":"slider","default":0.499900,"min":0.0,"max":1.0,"step":0.01}
 uniform float u_mv_dy = 0.000000; // {"widget":"slider","default":0.000000,"min":-0.1,"max":0.1,"step":0.001}
 uniform float u_mv_dx = 0.000000; // {"widget":"slider","default":0.000000,"min":-0.1,"max":0.1,"step":0.001}
@@ -76,6 +77,7 @@ uniform float u_mv_x = 12.0; // {"widget":"slider","default":12.0,"min":0.0,"max
 uniform float u_mv_y = 9.0; // {"widget":"slider","default":9.0,"min":0.0,"max":48.0,"step":1.0}
 uniform float u_ib_b = 0.000000; // {"widget":"slider","default":0.000000,"min":0.0,"max":1.0,"step":0.01}
 uniform float u_ib_g = 0.000000; // {"widget":"slider","default":0.000000,"min":0.0,"max":1.0,"step":0.01}
+uniform float u_echo_zoom = 1.0; // {"widget":"slider","default":1.0,"min":0.5,"max":2.0,"step":0.01}
 uniform float u_wave_b = 0.500000; // {"widget":"slider","default":0.500000,"min":0.0,"max":1.0,"step":0.01}
 uniform float u_wave_g = 0.500000; // {"widget":"slider","default":0.500000,"min":0.0,"max":1.0,"step":0.01}
 uniform float u_wave_r = 0.500000; // {"widget":"slider","default":0.500000,"min":0.0,"max":1.0,"step":0.01}
@@ -103,6 +105,7 @@ uniform float u_g = 0.0; // {"widget":"slider","default":0.0,"min":0.0,"max":1.0
 uniform float u_b = 0.0; // {"widget":"slider","default":0.0,"min":0.0,"max":1.0,"step":0.01}
 uniform float u_wave_mystery = 0.0; // {"widget":"slider","default":0.0,"min":-1.0,"max":1.0,"step":0.01}
 uniform float u_ob_size = 0.005000; // {"widget":"slider","default":0.005000,"min":0.0,"max":0.1,"step":0.001}
+uniform float u_echo_orient = 0.0; // {"widget":"slider","default":0.0,"min":0.0,"max":3.0,"step":1.0}
 uniform float u_ob_r = 1.000000; // {"widget":"slider","default":1.000000,"min":0.0,"max":1.0,"step":0.01}
 uniform float u_mv_r = 0.499900; // {"widget":"slider","default":0.499900,"min":0.0,"max":1.0,"step":0.01}
 uniform float u_ob_b = 0.000000; // {"widget":"slider","default":0.000000,"min":0.0,"max":1.0,"step":0.01}
@@ -113,6 +116,7 @@ uniform float u_ib_r = 0.000000; // {"widget":"slider","default":0.000000,"min":
 
 void main() {
     // Initialize local variables from uniforms
+    float echo_alpha = u_echo_alpha;
     float mv_b = u_mv_b;
     float mv_dy = u_mv_dy;
     float mv_dx = u_mv_dx;
@@ -120,6 +124,7 @@ void main() {
     float mv_y = u_mv_y;
     float ib_b = u_ib_b;
     float ib_g = u_ib_g;
+    float echo_zoom = u_echo_zoom;
     float wave_b = u_wave_b;
     float wave_g = u_wave_g;
     float wave_r = u_wave_r;
@@ -147,6 +152,7 @@ void main() {
     float b = u_b;
     float wave_mystery = u_wave_mystery;
     float ob_size = u_ob_size;
+    float echo_orient = u_echo_orient;
     float ob_r = u_ob_r;
     float mv_r = u_mv_r;
     float ob_b = u_ob_b;
@@ -276,6 +282,7 @@ void main() {
     mat2 rotation_matrix = mat2(cos(rot), -sin(rot), sin(rot), cos(rot));
     transformed_uv = rotation_matrix * transformed_uv;
 
+    transformed_uv *= warp;
     transformed_uv /= zoom;
     transformed_uv /= vec2(sx, sy);
 

--- a/MilkdropConverter.cpp
+++ b/MilkdropConverter.cpp
@@ -102,6 +102,9 @@ const std::unordered_map<std::string, UniformControl> uniformControls = {
     {"mv_g", {"1.0", "slider", "0.0", "1.0", "0.01"}},
     {"mv_b", {"1.0", "slider", "0.0", "1.0", "0.01"}},
     {"mv_a", {"0.0", "slider", "0.0", "1.0", "0.01"}},
+    {"echo_zoom", {"1.0", "slider", "0.5", "2.0", "0.01"}},
+    {"echo_alpha", {"0.0", "slider", "0.0", "1.0", "0.01"}},
+    {"echo_orient", {"0.0", "slider", "0.0", "3.0", "1.0"}},
 };
 
 class GLSLGenerator {
@@ -490,6 +493,7 @@ float rand(vec2 co){
     mat2 rotation_matrix = mat2(cos(rot), -sin(rot), sin(rot), cos(rot));
     transformed_uv = rotation_matrix * transformed_uv;
 
+    transformed_uv *= warp;
     transformed_uv /= zoom;
     transformed_uv /= vec2(sx, sy);
 


### PR DESCRIPTION
…orms

This commit fixes a critical bug that caused a blank/black screen when rendering converted shaders. The root causes were identified as:
1.  The `warp` variable was calculated in the per-pixel logic but never applied to the UV coordinates, resulting in a static feedback loop.
2.  The `echo_zoom` parameter, used in the `zoom` calculation, was not recognized by the converter and defaulted to 0.0, leading to incorrect transformations.

The following changes have been made:
- The GLSL transformation logic in `MilkdropConverter.cpp` has been updated to correctly apply the `warp` value to the `transformed_uv` coordinates.
- `echo_zoom`, `echo_alpha`, and `echo_orient` have been added to the `uniformControls` map, ensuring they are parsed from the `.milk` file and made available to the shader as uniforms.

These fixes restore the intended motion and visual feedback, resolving the black screen rendering issue.