### PR TITLE
Fix projectm-eval parser for multi-line statements

### DIFF
--- a/MilkdropConverter.cpp
+++ b/MilkdropConverter.cpp
@@ -505,19 +505,6 @@ float rand(vec2 co){
     }
     glsl += "\n    // Per-frame logic\n";
     glsl += perFrameGLSL;
-    glsl += "\n    // Dummy per-frame logic for animation and audio reaction\n";
-    glsl += "    q1 = dot(iAudioBands.xyz, vec3(1.0, 0.8, 0.6)) * 0.5;\n";
-    glsl += "    q2 = iTime * 0.1 + q1;\n";
-    glsl += "    wave_r = 0.5 + 0.4 * sin(q2);\n";
-    glsl += "    wave_g = 0.5 + 0.4 * cos(q2);\n";
-    glsl += "    wave_b = 0.3 + 0.2 * sin(q2 * 2.0);\n";
-    glsl += "    ob_r = 0.2;\n";
-    glsl += "    ob_g = 0.1;\n";
-    glsl += "    ob_b = 0.3;\n";
-    glsl += "    decay = 0.99;\n";
-    glsl += "    a = 1.0;\n";
-    glsl += "    q3 = 1.0;\n";
-    glsl += "    q4 = float_from_bool(sin(iTime) > 0.0);\n";
     glsl += "\n    // Per-pixel logic\n";
     glsl += perPixelGLSL;
     glsl += R"___(


### PR DESCRIPTION
The `projectm-eval` library contained a faulty optimization in the `prjm_eval_compiler_add_instruction` function. This optimization incorrectly discarded statements from a statement list if they were not marked as "state-changing," causing multi-line expressions in MilkDrop presets to be parsed incorrectly.

This change removes the faulty optimization, allowing the parser to correctly accumulate all statements in a list.

Additionally, this change includes:
- A patch to `PresetFileParser.cpp` to correctly concatenate multi-line code with spaces instead of newlines.
- Removal of dummy per-frame logic in `MilkdropConverter.cpp` that was a workaround for the parser bug.